### PR TITLE
Fix to Invoke-SeScreenshot to return Base64EncodedString

### DIFF
--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -164,8 +164,10 @@ function Invoke-SeScreenshot {
     param($Driver, [Switch]$AsBase64EncodedString)
 
     $Screenshot = [OpenQA.Selenium.Support.Extensions.WebDriverExtensions]::TakeScreenshot($Driver)
-    if ($AsBase64String) {
+    if ($AsBase64EncodedString) {
         $Screenshot.AsBase64EncodedString
+    } else {
+        $Screenshot
     }
 }
 


### PR DESCRIPTION
When running the following snippet, `Save-SeScreenshot` fails as `$Screenshot` is null.
```
$Screenshot = Invoke-SeScreenshot -Driver $Driver -AsBase64EncodedString
Save-SeScreenshot -Screenshot $Screenshot -Path "C:\temp\Step1.png"
```

This change corrects the variable checked in the if statement to be the same as the one passed in the switch parameter and returns the whole `$Screenshot` object otherwise.
