### PR TITLE
Linux/MacOS assemblies permission fix, Start-Chrome/Remove-SeCookie enchancements, Set-SeCookie $ExpiryDate issue fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Import-Module "{FullPath}\selenium-powershell\Selenium.psm1"
 ```
 
 # Usage
+`Note: in order to use a specific driver you will need to have the brower of the driver installed on your system.
+For example if you use Start-SeChrome you will need to have either a Chrome or Chromium browser installed
+`
 
 ## Start a Browser Driver
 ```powershell
@@ -38,7 +41,7 @@ $Driver = Start-SeFirefox
 Enter-SeUrl https://www.poshud.com -Driver $Driver
 ```
 
-## Find an element
+## Find an Element
 
 ```powershell
 $Driver = Start-SeFirefox 
@@ -46,7 +49,7 @@ Enter-SeUrl https://www.poshud.com -Driver $Driver
 $Element = Find-SeElement -Driver $Driver -Id "myControl"
 ```
 
-## Click on a button
+## Click on an Element/Button
 
 ```powershell
 $Driver = Start-SeFirefox 
@@ -74,13 +77,29 @@ $Driver = Start-SeChrome -Headless
 $Driver = Start-SeChrome -Incognito
 
 # Run Chrome with alternative download folder
-$Driver = Start-SeChrome -DefaultDownloadPath  c:\temp
+$Driver = Start-SeChrome -DefaultDownloadPath C:\Temp
+
+# Run Chrome and go to a URL in one command
+$Driver = Start-SeChrome -StartURL 'https://www.google.com/ncr'
+
+# Run Chrome with multiple Arguments
+$Driver = Start-SeChrome -Arguments @('Incognito','start-maximized')
+
+# Run Chrome with an existing profile.
+# The default profile paths are as follows:
+# Windows: C:\Users\<username>\AppData\Local\Google\Chrome\User Data
+# Linux: /home/<username>/.config/google-chrome
+# MacOS: /Users/<username>/Library/Application Support/Google/Chrome
+$Driver = Start-SeChrome -ProfileDirectoryPath '/home/<username>/.config/google-chrome'
+
 ```
 
-## Wait for an element
+## Find and Wait for an element
 ```powershell
 $Driver = Start-SeChrome
-Enter-SeUrl https://www.google.com -Driver $Driver
+Enter-SeUrl 'https://www.google.com/ncr' -Driver $Driver
+
+# Please note that with the -Wait parameter only one element can be returned at a time.
 Find-SeElement -Driver $d -Wait -Timeout 10 -Css input[name='q'] 
 Find-SeElement -Driver $d -Wait -Timeout 10 -Name q 
 ```

--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -64,11 +64,11 @@ function Start-SeChrome {
         $Chrome_Options = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeOptions"
     
         if($DefaultDownloadPath){
-            Write-Host "Setting Default Download directory: $DefaultDownloadPath"
+            Write-Verbose "Setting Default Download directory: $DefaultDownloadPath"
             $Chrome_Options.AddUserProfilePreference('download', @{'default_directory' = $($DefaultDownloadPath.FullName); 'prompt_for_download' = $false; })
         }
         if($ProfileDirectoryPath){
-            Write-Host "Setting Profile directory: $ProfileDirectoryPath"
+            Write-Verbose "Setting Profile directory: $ProfileDirectoryPath"
             $Chrome_Options.AddArgument("user-data-dir=$ProfileDirectoryPath")
         }
         
@@ -99,7 +99,7 @@ function Start-SeChrome {
         }
         
         if (!$HideVersionHint) {
-            Write-Host "Download the right chromedriver from 'http://chromedriver.chromium.org/downloads'" -ForegroundColor Yellow
+            Write-Verbose "Download the right chromedriver from 'http://chromedriver.chromium.org/downloads'"
         }
 
         if($IsLinux -or $IsMacOS){

--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -8,6 +8,25 @@ elseif($IsMacOS){
     $AssembliesPath = "$PSScriptRoot/assemblies/macos"
 }
 
+# Grant Execution permission to assemblies on Linux and MacOS 
+if($IsLinux -or $IsMacOS){
+    # Check if powershell is NOT running as root
+    $AssemblieFiles = Get-ChildItem -Path $AssembliesPath |Where-Object{$_.Name -eq 'chromedriver' -or $_.Name -eq 'geckodriver'}
+    foreach($AssemblieFile in $AssemblieFiles){
+        if($IsLinux){
+            $FileMod = stat -c "%a" $AssemblieFile.fullname
+        }
+        elseif($IsMacOS){
+            $FileMod = /usr/bin/stat -f "%A" $AssemblieFile.fullname
+        }
+
+        if($FileMod[2] -ne '5' -and $FileMod[2] -ne '7' ){
+            Write-Host "Granting $($AssemblieFile.fullname) Execution Permissions ..."
+            chmod +x $AssemblieFile.fullname
+        }
+    }
+}
+
 function Start-SeChrome {
     Param(
         [Parameter(Mandatory = $false)]

--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -13,49 +13,94 @@ function Start-SeChrome {
         [Parameter(Mandatory = $false)]
         [array]$Arguments,
         [switch]$HideVersionHint,
+        [string]$StartURL,
         [System.IO.FileInfo]$DefaultDownloadPath,
+        [System.IO.FileInfo]$ProfileDirectoryPath,
         [bool]$DisableBuiltInPDFViewer=$true,
         [switch]$Headless,
         [switch]$Incognito,
-        [switch]$Maximized
+        [switch]$Maximized,
+        [switch]$Minimized,
+        [switch]$Fullscreen
     )
 
-    $Chrome_Options = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeOptions"
-    
-    if($DefaultDownloadPath){
-        Write-Host "Setting Default Download directory: $DefaultDownloadPath"
-        $Chrome_Options.AddUserProfilePreference('download', @{'default_directory' = $($DefaultDownloadPath.FullName); 'prompt_for_download' = $false; })
-    }
-    
-    if($DisableBuiltInPDFViewer){
-       $Chrome_Options.AddUserProfilePreference('plugins', @{'always_open_pdf_externally' =  $true;})
-    }
-    
-    if ($Headless) {
-        $Chrome_Options.AddArguments('headless')
-    }
+    BEGIN{
+        if($Maximized -ne $false -and $Minimized -ne $false) {
+            throw 'Maximized and Minimized may not be specified together.'
+        }
+        elseif($Maximized -ne $false -and $Fullscreen -ne $false){
+            throw 'Maximized and Fullscreen may not be specified together.'
+        }
+        elseif($Minimized -ne $false -and $Fullscreen -ne $false){
+            throw 'Minimized and Fullscreen may not be specified together.'
+        }
 
-    if ($Incognito) {
-        $Chrome_Options.AddArguments('Incognito')
+        if($StartURL){
+            if(![system.uri]::IsWellFormedUriString($StartURL,[System.UriKind]::Absolute)){
+                throw 'Incorrect StartURL please make sure the URL starts with http:// or https://'
+            }
+        }
     }
-
-    if ($Maximized) {
-        $Chrome_Options.AddArguments('start-maximized')
-    }
-
-    if ($Arguments) {
-        $Chrome_Options.AddArguments($Arguments)
-    }
+    PROCESS{
+        $Chrome_Options = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeOptions"
     
-    if (!$HideVersionHint) {
-        Write-Host "Download the right chromedriver from 'http://chromedriver.chromium.org/downloads'" -ForegroundColor Yellow
-    }
+        if($DefaultDownloadPath){
+            Write-Host "Setting Default Download directory: $DefaultDownloadPath"
+            $Chrome_Options.AddUserProfilePreference('download', @{'default_directory' = $($DefaultDownloadPath.FullName); 'prompt_for_download' = $false; })
+        }
+        if($ProfileDirectoryPath){
+            Write-Host "Setting Profile directory: $ProfileDirectoryPath"
+            $Chrome_Options.AddArgument("user-data-dir=$ProfileDirectoryPath")
+        }
+        
+        if($DisableBuiltInPDFViewer){
+            $Chrome_Options.AddUserProfilePreference('plugins', @{'always_open_pdf_externally' =  $true;})
+        }
+        
+        if ($Headless) {
+            $Chrome_Options.AddArguments('headless')
+        }
 
-    if($IsLinux -or $IsMacOS){
-        New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeDriver" -ArgumentList $AssembliesPath,$Chrome_Options
+        if ($Incognito) {
+            $Chrome_Options.AddArguments('Incognito')
+        }
+
+        if ($Maximized) {
+            $Chrome_Options.AddArguments('start-maximized')
+        }
+
+        if ($Fullscreen) {
+            $Chrome_Options.AddArguments('start-fullscreen')
+        }
+
+        if ($Arguments) {
+            foreach ($Argument in $Arguments){
+                $Chrome_Options.AddArguments($Argument)
+            }
+        }
+        
+        if (!$HideVersionHint) {
+            Write-Host "Download the right chromedriver from 'http://chromedriver.chromium.org/downloads'" -ForegroundColor Yellow
+        }
+
+        if($IsLinux -or $IsMacOS){
+            $Driver = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeDriver" -ArgumentList $AssembliesPath,$Chrome_Options
+        }
+        else{
+            $Driver = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeDriver" -ArgumentList $Chrome_Options 
+        }
+
+        if($Minimized){
+            $driver.Manage().Window.Minimize();
+
+        }
+
+        if($StartURL){
+            Enter-SeUrl -Driver $Driver -Url $StartURL
+        }
     }
-    else{
-        New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeDriver" -ArgumentList $Chrome_Options 
+    END{
+        return $Driver
     }
 }
 
@@ -264,20 +309,29 @@ function Get-SeCookie {
 }
 
 function Remove-SeCookie {
-    param($Driver)
-    
-    $Driver.Manage().Cookies.DeleteAllCookies()
+    param(
+        $Driver,
+        [switch]$DeleteAllCookies,
+        [string]$Name
+    )
+
+    if($DeleteAllCookies){
+        $Driver.Manage().Cookies.DeleteAllCookies()
+    }
+    else{
+        $Driver.Manage().Cookies.DeleteCookieNamed($Name)
+    }
 }
 
 function Set-SeCookie {
     param(
-        $Driver, 
-        [string]$Name, 
+        [ValidateNotNull()]$Driver, 
+        [string]$Name,
         [string]$Value,
         [string]$Path,
         [string]$Domain,
-        [datetime]$ExpiryDate
-        )
+        $ExpiryDate
+    )
 
     <# Selenium Cookie Information
     Cookie(String, String)
@@ -289,37 +343,44 @@ function Set-SeCookie {
     Cookie(String, String, String, String, Nullable<DateTime>)
     Initializes a new instance of the Cookie class with a specific name, value, domain, path and expiration date. 
     #>
+    Begin{
+        if($ExpiryDate -ne $null -and $ExpiryDate.GetType().Name -ne 'DateTime'){
+            throw '$ExpiryDate can only be $null or TypeName: System.DateTime'
+        }
+    }
 
-    if($Name -and $Value -and (!$Path -and !$Domain -and !$ExpiryDate)){
-        $cookie = New-Object -TypeName OpenQA.Selenium.Cookie -ArgumentList $Name,$Value
-    }
-    Elseif($Name -and $Value -and $Path -and (!$Domain -and !$ExpiryDate)){
-        $cookie = New-Object -TypeName OpenQA.Selenium.Cookie -ArgumentList $Name,$Value,$Path
-    }
-    Elseif($Name -and $Value -and $Path -and $ExpiryDate -and !$Domain){
-        $cookie = New-Object -TypeName OpenQA.Selenium.Cookie -ArgumentList $Name,$Value,$Path,$ExpiryDate
-    }
-    Elseif($Name -and $Value -and $Path -and $ExpiryDate -and $Domain){
-        if($Driver.Url -match $Domain){
-            $cookie = New-Object -TypeName OpenQA.Selenium.Cookie -ArgumentList $Name,$Value,$Domain,$Path,$ExpiryDate
+    Process {
+        if($Name -and $Value -and (!$Path -and !$Domain -and !$ExpiryDate)){
+            $cookie = New-Object -TypeName OpenQA.Selenium.Cookie -ArgumentList $Name,$Value
+        }
+        Elseif($Name -and $Value -and $Path -and (!$Domain -and !$ExpiryDate)){
+            $cookie = New-Object -TypeName OpenQA.Selenium.Cookie -ArgumentList $Name,$Value,$Path
+        }
+        Elseif($Name -and $Value -and $Path -and $ExpiryDate -and !$Domain){
+            $cookie = New-Object -TypeName OpenQA.Selenium.Cookie -ArgumentList $Name,$Value,$Path,$ExpiryDate
+        }
+        Elseif($Name -and $Value -and $Path -and $Domain -and (!$ExpiryDate -or $ExpiryDate)){
+            if($Driver.Url -match $Domain){
+                $cookie = New-Object -TypeName OpenQA.Selenium.Cookie -ArgumentList $Name,$Value,$Domain,$Path,$ExpiryDate
+            }
+            else{
+                Throw 'In order to set the cookie the browser needs to be on the cookie domain URL'
+            }
         }
         else{
-            Throw 'In order to set the cookie the browser needs to be on the cookie domain URL'
+            Throw "Incorrect Cookie Layout:
+            Cookie(String, String)
+            Initializes a new instance of the Cookie class with a specific name and value.
+            Cookie(String, String, String)
+            Initializes a new instance of the Cookie class with a specific name, value, and path.
+            Cookie(String, String, String, Nullable<DateTime>)
+            Initializes a new instance of the Cookie class with a specific name, value, path and expiration date.
+            Cookie(String, String, String, String, Nullable<DateTime>)
+            Initializes a new instance of the Cookie class with a specific name, value, domain, path and expiration date."
         }
-    }
-    else{
-        Throw "Incorrect Cookie Layout:
-        Cookie(String, String)
-        Initializes a new instance of the Cookie class with a specific name and value.
-        Cookie(String, String, String)
-        Initializes a new instance of the Cookie class with a specific name, value, and path.
-        Cookie(String, String, String, Nullable<DateTime>)
-        Initializes a new instance of the Cookie class with a specific name, value, path and expiration date.
-        Cookie(String, String, String, String, Nullable<DateTime>)
-        Initializes a new instance of the Cookie class with a specific name, value, domain, path and expiration date."
-    }
 
-    $Driver.Manage().Cookies.AddCookie($cookie)
+        $Driver.Manage().Cookies.AddCookie($cookie)
+    }
 }
 
 function Get-SeElementAttribute {

--- a/Selenium.tests.ps1
+++ b/Selenium.tests.ps1
@@ -7,56 +7,56 @@ Describe "Verify the Binaries SHA256 Hash" {
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\WebDriver.dll.sha256)
     }
 
-    It "Check WebDriver.Support.dll Hash"{
+    It "Check WebDriver.Support.dll Hash" {
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/b59ba7d0cffe43e722b13ad737cf596f030788b86b5b557cb479f0b6957cce8a/detection
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\WebDriver.Support.dll).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\WebDriver.Support.dll.sha256)
     }
 
-    It "Check ChromeDriver.exe Hash"{
+    It "Check ChromeDriver.exe Hash" {
         # The ChromeDriver.exe was extracted from https://chromedriver.storage.googleapis.com/76.0.3809.68/chromedriver_win32.zip its VirusTotal Scan URL - https://www.virustotal.com/gui/url/69ffe387a3fa4fbf8a108391580f1a0befb8b96b82486da4417cfcdab4add4d4/detection
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/66cfa645f83fde41720beac7061a559fd57b6f5caa83d7918f44de0f4dd27845/detection
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\chromedriver.exe).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\chromedriver.exe.sha256)
     }
     
-    It "Check ChromeDriver Linux Hash"{
+    It "Check ChromeDriver Linux Hash" {
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/3da69344b8b2b3b7e1497378672231a179eed6b3a0fdccbfacd3d053612e2547/detection
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\linux\chromedriver).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\linux\chromedriver.sha256)
     }
 
-    It "Check ChromeDriver MacOS Hash"{
+    It "Check ChromeDriver MacOS Hash" {
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/57097bb65200f003152906c831ccd226ebbd5a9fd47df46f18adc29f7d01f2f0/detection
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\macos\chromedriver).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\macos\chromedriver.sha256)
     }
 
-    It "Check GeckoDriver.exe Hash"{
+    It "Check GeckoDriver.exe Hash" {
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/1ae81b2a6f40f7d11be3c91c4d83977ae0c0897bd5d154c02a6d869b58866b58/detection
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\geckodriver.exe).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\geckodriver.exe.sha256)
     }
 
-    It "Check GeckoDriver Linux Hash"{
+    It "Check GeckoDriver Linux Hash" {
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/4490a47280ab38f68511ac0dfff214bfad89bfd5442b1c3096c28d5372dfe2e9/detection
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\linux\geckodriver).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\linux\geckodriver.sha256)
     }
 
-    It "Check GeckoDriver MacOS Hash"{
+    It "Check GeckoDriver MacOS Hash" {
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/1f3873a8ee0b2cb9f2918329cbdf0d65e45c0182127ea03520bec70f0dab3917/detection
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\macos\geckodriver).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\macos\geckodriver.sha256)
     }
 
-    It "Check IEDriverServer.exe Hash"{
+    It "Check IEDriverServer.exe Hash" {
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/a1e26b0e8cb5f8db1cd784bac71bbf540485d81e697293b0b4586e25a31a8187/detection - this driver seems to have 2 false positives and is marked as clean in the comments
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\IEDriverServer.exe).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\IEDriverServer.exe.sha256)
     }
 
-    It "Check MicrosoftWebDriver.exe Hash"{
+    It "Check MicrosoftWebDriver.exe Hash" {
         # VirusTotal Scan URL = https://www.virustotal.com/gui/file/6e8182697ea5189491b5519d8496a3392e43741b7c0515130f2f8205881d208e/detection
         $Hash = (Get-FileHash -Algorithm SHA256 -Path $PSScriptRoot\assemblies\MicrosoftWebDriver.exe).Hash
         $Hash |Should Be (Get-Content -Path $PSScriptRoot\assemblies\MicrosoftWebDriver.exe.sha256)
@@ -70,38 +70,40 @@ Describe "Start-SeChrome" {
     }
 }
 
-Describe "Start-SeChrome headless" {
-    Context "Should Start Chrome Driver in headless mode" {
-        $Driver = Start-SeChrome -Headless
-        Stop-SeDriver $Driver
-    }
-}
-
 Describe "Start-SeChrome with Options" {
     Context "Should Start Chrome Driver with different startup options" {
-        It "Start Chrome in Headless mode"{
+        It "Start Chrome in Headless mode" {
             $Driver = Start-SeChrome -Headless
             Stop-SeDriver $Driver
         }
 
-        It "Start Chrome Maximized "{
+        It "Start Chrome Maximized" {
             $Driver = Start-SeChrome -Maximized
             Stop-SeDriver $Driver
         }
 
-        It "Start Chrome Incognito "{
+        It "Start Chrome Incognito" {
             $Driver = Start-SeChrome -Incognito
             Stop-SeDriver $Driver
         }
+        
+        It "Start Chrome Fullscreen" {
+            $Driver = Start-SeChrome -Fullscreen
+            Stop-SeDriver $Driver
+        }
 
-        It "Start Chrome Maximized and Incognito "{
+        It "Start Chrome Maximized and Incognito" {
             $Driver = Start-SeChrome -Maximized -Incognito
             Stop-SeDriver $Driver
+        }
+
+        It "Start Chrome with Multiple arguments" {
+            $Driver = Start-SeChrome -Arguments @('Incognito','start-maximized')
         }
     }
 }
 
-Describe "Start-SeFirefox" {
+Describe "Start-SeFirefox"{
     Context "Should Start Firefox Driver" {
         $Driver = Start-SeFirefox 
         Stop-SeDriver $Driver


### PR DESCRIPTION
1) Check Linux and MacOS assemblies files execution and fix them if incorrect.
2) Added Start-SeChrome Minimized and Fullscreen
3) Added Start-SeChrome StartURL parameter to specify a URL that chrome will go to on startup.
4) Added the option to specify a ProfileDirectoryPath in Start-SeChrome
5) Added better handeling of multiple arguments in Start-SeChrome
6) Added the option to delete a cookie by name to Remove-SeCookie
7) Fixed an issue that prevented $null value in Set-SeCookie $ExpiryDate
8) Added appropriate tests to Selenium.tests.ps1
8) Made appropriate changes to README.md to replace the above changes.
