### PR TITLE
Added switch SupressLogging to Start-SeFirefox.

### DIFF
--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -156,7 +156,8 @@ function Start-SeFirefox {
         [switch]$PrivateBrowsing,
         [switch]$Maximized,
         [switch]$Minimized,
-        [switch]$Fullscreen
+        [switch]$Fullscreen,
+        [switch]$SuppressLogging
     )
 
     BEGIN{
@@ -197,6 +198,11 @@ function Start-SeFirefox {
             foreach ($Argument in $Arguments){
                 $Firefox_Options.AddArguments($Argument)
             }
+        }
+
+        if($SuppressLogging){
+            # Sets GeckoDriver log level to Fatal.
+            $Firefox_Options.LogLevel = 6
         }
 
         if($IsLinux -or $IsMacOS){


### PR DESCRIPTION
# Changes
* This PR adds the switch `-SuppressLogging` to `Start-SeFirefox`. This sets the GeckoDriver LogLevel to Fatal (int value 6). 

* This fixes my issue #45 

Using this switch ensures that no output is presented to stdout.