### PR TITLE
Add custom DriverPath to Start-SeChrome

### DIFF
--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -49,7 +49,10 @@ function Start-SeChrome {
         [switch]$Maximized,
         [switch]$Minimized,
         [switch]$Fullscreen,
-        [System.IO.FileInfo]$ChromeBinaryPath
+        [System.IO.FileInfo]$ChromeBinaryPath,
+
+        [ValidateScript({  if ($_) {Test-Path -Path $_ -PathType Container}  })]
+        [string]$DriverPath
     )
 
     BEGIN{
@@ -118,11 +121,14 @@ function Start-SeChrome {
             Write-Verbose "Download the right chromedriver from 'http://chromedriver.chromium.org/downloads'"
         }
 
-        if($IsLinux -or $IsMacOS){
+        if ($DriverPath){
+            $Driver = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeDriver" -ArgumentList $DriverPath,$Chrome_Options
+        }
+        elseif($IsLinux -or $IsMacOS){
             $Driver = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeDriver" -ArgumentList $AssembliesPath,$Chrome_Options
         }
         else{
-            $Driver = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeDriver" -ArgumentList $Chrome_Options 
+            $Driver = New-Object -TypeName "OpenQA.Selenium.Chrome.ChromeDriver" -ArgumentList $Chrome_Options
         }
 
         if($Minimized -and $Driver){

--- a/Selenium.tests.ps1
+++ b/Selenium.tests.ps1
@@ -150,7 +150,6 @@ Describe 'Start-SeChrome with Custom DriverPath' {
 
         It 'Start-SeChrome with multiple arguments should fail if custom DriverPath does not exist' {
         { 
-            $driverPath | Should Not BeNullOrEmpty
             Start-SeChrome -DriverPath $badDriverPath -Arguments @('Incognito','start-maximized') } | Should Throw
         }
     }

--- a/Selenium.tests.ps1
+++ b/Selenium.tests.ps1
@@ -113,6 +113,49 @@ Describe "Start-SeChrome with Options" {
     }
 }
 
+Describe 'Start-SeChrome with Custom DriverPath' {
+    BeforeEach {
+        # It is unknown which alternate drivers are present on CI agent, so use existing driver as a custom DriverPath for tests
+        if ($IsLinux) {
+            $driverPath = Join-Path $PSScriptRoot 'assemblies/macos'
+        }
+        elseif($IsMacOS) {
+            $driverPath = Join-Path $PSScriptRoot 'assemblies/linux'
+        }
+        else { #windows
+            $driverPath = Join-Path $PSScriptRoot 'assemblies'
+        }
+
+        $badDriverPath = Join-Path $PSScriptRoot 'bad-assembly-path'
+    }
+
+    Context 'DriverPath With no additional arguments' {
+        It 'Start-SeChrome from Custom DriverPath with no arguments' {
+            $Driver = Start-SeChrome -DriverPath $driverPath
+            $Driver | Should Not BeNullOrEmpty
+            Stop-SeDriver $Driver
+        }
+
+        It 'Start-SeChrome should fail if custom DriverPath does not exist' {
+            { Start-SeChrome -DriverPath $badDriverPath } | Should Throw
+        }
+    }
+
+    Context 'DriverPath With additional arguments' {
+        It 'Start-SeChrome from Custom DriverPath with Multiple arguments' {
+            $Driver = Start-SeChrome -DriverPath $driverPath -Arguments @('Incognito','start-maximized')
+            $Driver | Should Not BeNullOrEmpty
+            Stop-SeDriver $Driver
+        }
+
+        It 'Start-SeChrome with multiple arguments should fail if custom DriverPath does not exist' {
+        { 
+            $driverPath | Should Not BeNullOrEmpty
+            Start-SeChrome -DriverPath $badDriverPath -Arguments @('Incognito','start-maximized') } | Should Throw
+        }
+    }
+}
+
 Describe "Start-SeFirefox"{
     Context "Should Start Firefox Driver" {
         $Driver = Start-SeFirefox 


### PR DESCRIPTION
In some cases different version(s) of ChromeDriver may be required for testing. An example of this would be when using ChromeDriver to test Electron based applications in which an old version of ChromeDriver is required.

This PR adds a parameter `-DriverPath` to Start-SeChrome to allow loading ChromeDriver from a path chosen by the operator (or an accompanying satellite version management process as suggested in #50 ). This enables one or more custom versions of ChromeDriver to be used (such as for an Electron App and its web-hosted cousin).

This approach was used because this module should carry responsibility for distributing long dated versions of chromedriver.exe (or its friends)