### PR TITLE
Add DisableAutomationExtension Switch

### DIFF
--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -180,6 +180,7 @@ function Start-SeChrome {
         [switch]$Minimized,
         [parameter(ParameterSetName='Ful',Mandatory=$true)]
         [switch]$Fullscreen,
+		[switch]$DisableAutomationExtension,
         [Alias('ChromeBinaryPath')]
         $BinaryPath,
         $WebDriverDirectory = $env:ChromeWebDriver,
@@ -225,6 +226,11 @@ function Start-SeChrome {
 
         if($Fullscreen){
             $Chrome_Options.AddArguments('start-fullscreen')
+        }
+		
+		if($DisableAutomationExtension){
+            $Chrome_Options.AddAdditionalCapability('useAutomationExtension', $false)
+            $Chrome_Options.AddExcludedArgument('enable-automation')
         }
 
         if($Arguments){


### PR DESCRIPTION
This PR adds a DisableAutomationExtension switch to `Start-SeChrome` which does the following on the $Chrome_Options object prior to starting the driver:

```powershell
$Chrome_Options.AddAdditionalCapability('useAutomationExtension', $false)
$Chrome_Options.AddExcludedArgument('enable-automation')
```

When the automation extension is disabled, you no longer get the "Chrome is being controlled by automated test software" info bar, which I needed to remove as I'm automating a wallboard with this and that persisted in fullscreen mode.

The specific settings changes are as per: https://stackoverflow.com/a/57782058/170183 & https://www.edureka.co/community/145/notification-controlled-automated-software-chromedriver