### PR TITLE
Fix Invoke-SeClick not looking for a default driver when using -JavaScriptClick

### DIFF
--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -782,7 +782,16 @@ function Invoke-SeClick {
     )
 
     if ($JavaScriptClick) {
-        $Driver.ExecuteScript("arguments[0].click()", $Element)
+    	if (-not $PSBoundParameters.ContainsKey("Driver")) {
+	    $Driver = $global:SeDriver
+	}
+
+	try {
+            $Driver.ExecuteScript("arguments[0].click()", $Element)
+	}
+	catch {
+	    $PSCmdlet.ThrowTerminatingError($_)
+	}
     }
     else {
         $Element.Click()

--- a/Selenium.psm1
+++ b/Selenium.psm1
@@ -772,20 +772,21 @@ function Get-SeElement {
 }
 
 function Invoke-SeClick {
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param(
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'Default')]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'JavaScript')]
         [OpenQA.Selenium.IWebElement]$Element,
-        [Parameter()]
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'JavaScript')]
         [Switch]$JavaScriptClick,
-        [Parameter()]
-        $Driver
+
+        [Parameter(ParameterSetName = 'JavaScript')]
+	[ValidateIsWebDriverAttribute()]
+        $Driver = $global:SeDriver
     )
 
     if ($JavaScriptClick) {
-    	if (-not $PSBoundParameters.ContainsKey("Driver")) {
-	    $Driver = $global:SeDriver
-	}
-
 	try {
             $Driver.ExecuteScript("arguments[0].click()", $Element)
 	}


### PR DESCRIPTION
Resolves #89 by ensuring it will look for a driver in the global variable space if a driver is not manually specified.

Also added some better error handling so the errors are a bit less noisy and confusing if it does happen to throw an error.