### PR TITLE
#91 Support for user agent

### DIFF
--- a/Classes/SeDriverUserAgentCompleter.ps1
+++ b/Classes/SeDriverUserAgentCompleter.ps1
@@ -1,0 +1,26 @@
+﻿class SeDriverUserAgentCompleter : System.Management.Automation.IArgumentCompleter {
+    [System.Collections.Generic.IEnumerable[System.Management.Automation.CompletionResult]] CompleteArgument(
+        [string]      $CommandName ,
+        [string]      $ParameterName,
+        [string]      $WordToComplete,
+        [System.Management.Automation.Language.CommandAst]  $CommandAst,
+        [system.Collections.IDictionary] $FakeBoundParameters
+    ) { 
+        $CompletionResults = [System.Collections.Generic.List[System.Management.Automation.CompletionResult]]::new()
+       
+        $pvalue = [System.Management.Automation.CompletionResultType]::ParameterValue
+
+        [System.Collections.Generic.List[PSObject]]$Predefined = 
+        [Microsoft.PowerShell.Commands.PSUserAgent].GetProperties() |
+            Select-Object Name, @{n = 'UserAgent'; e = { [Microsoft.PowerShell.Commands.PSUserAgent]::$($_.Name) } }
+        
+        $Predefined.Add([PSCustomObject]@{Name = 'Android'; UserAgent = 'Android' })
+        $Predefined.Add([PSCustomObject]@{Name = 'Iphone'; UserAgent = 'Iphone' })
+
+        $Predefined |
+            ForEach-Object { 
+                $CompletionResults.Add(([System.Management.Automation.CompletionResult]::new($_.Name, $_.Name, $pvalue, $_.UserAgent) ) ) 
+            }
+        return $CompletionResults
+    }
+}

--- a/Classes/SeDriverUserAgentTransformAttribute.ps1
+++ b/Classes/SeDriverUserAgentTransformAttribute.ps1
@@ -1,0 +1,25 @@
+﻿class SeDriverUserAgentTransformAttribute : System.Management.Automation.ArgumentTransformationAttribute {
+    # Implement the Transform() method
+    [object] Transform([System.Management.Automation.EngineIntrinsics]$engineIntrinsics, [object] $inputData) {
+        <#
+            The parameter value(s) are passed in here as $inputData. We aren't accepting array input
+            for our function, but it's good to make these fairly versatile where possible, so that
+            you can reuse them easily!
+        #>
+        $outputData = switch ($inputData) {
+            { $_ -is [string] } { 
+                $output = [Microsoft.PowerShell.Commands.PSUserAgent]::$_
+                if ($null -ne $output) { $output } else { $_ }
+            }
+            default {
+                # If we hit something we can't convert, throw an exception
+                throw [System.Management.Automation.ArgumentTransformationMetadataException]::new(
+                    "Only String attributes are supported."
+                )
+            }
+        }
+
+        return $OutputData
+    }
+
+}

--- a/Internal/Start-SeChromeDriver.ps1
+++ b/Internal/Start-SeChromeDriver.ps1
@@ -13,7 +13,8 @@ function Start-SeChromeDriver {
         [OpenQA.Selenium.DriverService]$service,
         [OpenQA.Selenium.DriverOptions]$Options,
         [String[]]$Switches,
-        [OpenQA.Selenium.LogLevel]$LogLevel
+        [OpenQA.Selenium.LogLevel]$LogLevel,
+        $UserAgent
         
 
 
@@ -44,6 +45,11 @@ function Start-SeChromeDriver {
         if ($DefaultDownloadPath) {
             Write-Verbose "Setting Default Download directory: $DefaultDownloadPath"
             $Options.AddUserProfilePreference('download', @{'default_directory' = $($DefaultDownloadPath.FullName); 'prompt_for_download' = $false; })
+        }
+
+        if ($UserAgent) {
+            Write-Verbose "Setting User Agent: $UserAgent"
+            $Options.AddArgument("--user-agent=$UserAgent")
         }
 
         if ($ProfilePath) {

--- a/Internal/Start-SeFirefoxDriver.ps1
+++ b/Internal/Start-SeFirefoxDriver.ps1
@@ -13,7 +13,8 @@ function Start-SeFirefoxDriver {
         [OpenQA.Selenium.DriverService]$service,
         [OpenQA.Selenium.DriverOptions]$Options,
         [String[]]$Switches,
-        [OpenQA.Selenium.LogLevel]$LogLevel
+        [OpenQA.Selenium.LogLevel]$LogLevel,
+        [String]$UserAgent
         
     )
     process {
@@ -28,6 +29,11 @@ function Start-SeFirefoxDriver {
             Write-Verbose "Setting Default Download directory: $DefaultDownloadPath"
             $Firefox_Options.setPreference("browser.download.folderList", 2);
             $Firefox_Options.SetPreference("browser.download.dir", "$DefaultDownloadPath");
+        }
+
+        if ($UserAgent) {
+            Write-Verbose "Setting User Agent: $UserAgent"
+            $Firefox_Options.SetPreference("general.useragent.override", $UserAgent)
         }
 
         if ($PrivateBrowsing) {

--- a/Internal/Test-SeDriverUserAgent.ps1
+++ b/Internal/Test-SeDriverUserAgent.ps1
@@ -1,0 +1,18 @@
+﻿function Test-SeDriverUserAgent {
+    [CmdletBinding()]
+    param (
+        $Browser, [ref]$UserAgent,
+        $Boundparameters
+    )
+
+    $SupportedBrowsers = @('Chrome', 'Firefox')
+    if ($Browser -in $SupportedBrowsers) { 
+        return 
+    }
+    else {
+        Throw ([System.NotImplementedException]::new(@"
+UserAgent parameter is only supported by the following browser: $($SupportedBrowsers -join ',')
+Selected browser: $Browser
+"@))
+    }
+}

--- a/Public/Start-SeDriver.ps1
+++ b/Public/Start-SeDriver.ps1
@@ -37,7 +37,7 @@ function Start-SeDriver {
         [SeDriverUserAgentTransformAttribute()]
         [ValidateNotNull()]
         [ArgumentCompleter( [SeDriverUserAgentCompleter])]
-        $UserAgent
+        [String]$UserAgent
         # See ParametersToRemove to view parameters that should not be passed to browsers internal implementations.
     )
     Begin {

--- a/Public/Start-SeDriver.ps1
+++ b/Public/Start-SeDriver.ps1
@@ -33,9 +33,16 @@ function Start-SeDriver {
         $ProfilePath,
         [OpenQA.Selenium.LogLevel]$LogLevel,
         [ValidateNotNullOrEmpty()]
-        $Name 
+        $Name,
+        [SeDriverUserAgentTransformAttribute()]
+        [ValidateNotNull()]
+        [ArgumentCompleter( [SeDriverUserAgentCompleter])]
+        $UserAgent
         # See ParametersToRemove to view parameters that should not be passed to browsers internal implementations.
     )
+    Begin {
+        if ($PSBoundParameters.ContainsKey('UserAgent')) { Test-SeDriverUserAgent -Browser $Browser -ErrorAction Stop }
+    }
     process {
         #Params with default value that need to be pased down to Start-SeXXDriver
         $OptionalParams = @('ImplicitWait', 'State')


### PR DESCRIPTION
Chrome / Firefox only. Throw an error if attempted with any other browser.


Argument completer for PSUserAgent.
Name is used but transformer will translate predefined user agent to their proper string.
Any other string is used as is. 

![image](https://user-images.githubusercontent.com/1980296/94997797-7828fb00-057b-11eb-83ac-38c96803b8af.png)


