### PR TITLE
Selenium-Binary-Updater.ps1 to download from Chrome for Testing endpoints

### DIFF
--- a/Selenium-Binary-Updater.ps1
+++ b/Selenium-Binary-Updater.ps1
@@ -21,7 +21,7 @@ switch ($Browser){
 
         $version = $currentVersionDownloads.versions |? { $_.version -eq $latestChromeStableVersion }
         if(-not $version) {
-            Write-Host "Unable to find download information for latest stable Chrome version '$latestChromeStableVersion' from '$"
+            Write-Host "Unable to find download information for latest stable Chrome version '$latestChromeStableVersion' from '$cftKnownGoodVersionsUrl`. Exiting."
         }
 
         $ChromeBuilds = @('chromedriver_linux64','chromedriver_mac64','chromedriver_win32')

--- a/Selenium-Binary-Updater.ps1
+++ b/Selenium-Binary-Updater.ps1
@@ -6,7 +6,24 @@ $TempDir = [System.IO.Path]::GetTempPath()
 
 switch ($Browser){
     'Chrome'{
-        $LatestChromeStableRelease = Invoke-WebRequest 'https://chromedriver.storage.googleapis.com/LATEST_RELEASE' | Select-Object -ExpandProperty Content
+        $cftUrl = "https://googlechromelabs.github.io/chrome-for-testing/"
+        $cftContent = (Invoke-WebRequest -Uri $cftUrl -UseBasicParsing).Content
+        if($cftContent -match "<h2>Stable</h2><p>Version: <code>([^<]+)</code>") {
+            $latestChromeStableVersion = $matches[1]
+        } else {
+            Write-Host "Unable to determine latest stable release number of Chrome from '$cftUrl'. Exiting."
+            return
+        }
+
+        $cftKnownGoodVersionsUrl = "https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json"
+        $currentVersionDownloadsContent = (Invoke-WebRequest -Uri $cftKnownGoodVersionsUrl -UseBasicParsing).Content
+        $currentVersionDownloads = ConvertFrom-Json -InputObject $currentVersionDownloadsContent
+
+        $version = $currentVersionDownloads.versions |? { $_.version -eq $latestChromeStableVersion }
+        if(-not $version) {
+            Write-Host "Unable to find download information for latest stable Chrome version '$latestChromeStableVersion' from '$"
+        }
+
         $ChromeBuilds = @('chromedriver_linux64','chromedriver_mac64','chromedriver_win32')
         
         foreach ($Build in $ChromeBuilds){
@@ -14,25 +31,38 @@ switch ($Browser){
                 'chromedriver_linux64'{
                     $AssembliesDir = "$PSScriptRoot/assemblies/linux"
                     $BinaryFileName = 'chromedriver'
+                    $DownloadUrl = ($version.downloads.chromedriver |? { $_.platform -eq "linux64" }).url
+                    $ExtraExpandDirName = "chromedriver-linux64"
                     }
                 'chromedriver_mac64'{
                     $AssembliesDir = "$PSScriptRoot/assemblies/macos"
                     $BinaryFileName = 'chromedriver'
+                    $DownloadUrl = ($version.downloads.chromedriver |? { $_.platform -eq "mac-x64" }).url
+                    $ExtraExpandDirName = "chromedriver-mac-x64"
                     }
                 'chromedriver_win32'{
                     $AssembliesDir = "$PSScriptRoot/assemblies"
                     $BinaryFileName = 'chromedriver.exe'
+                    $DownloadUrl = ($version.downloads.chromedriver |? { $_.platform -eq "win32" }).url
+                    $ExtraExpandDirName = "chromedriver-win32"
                     }
                 default{throw 'Incorrect Build Type'}
             }
         
             $BuildFileName = "$Build.zip"
+            $downloadPath = $TempDir + $BuildFileName
             Write-Verbose "Downloading: $BuildFileName"
-            Invoke-WebRequest -OutFile "$($TempDir + $BuildFileName)" "https://chromedriver.storage.googleapis.com/$LatestChromeStableRelease/$BuildFileName" 
+            Invoke-WebRequest -OutFile $downloadPath $DownloadUrl
             
             # Expand the ZIP Archive to the correct Assemblies Dir 
-            Write-Verbose "Explanding: $($TempDir + $BuildFileName) to $AssembliesDir"
-            Expand-Archive -Path "$($TempDir + $BuildFileName)" -DestinationPath $AssembliesDir -Force
+            Write-Verbose "Expanding: $downloadPath to $AssembliesDir"
+            Expand-Archive -Path $downloadPath -DestinationPath $AssembliesDir -Force
+
+            $extraAssembliesDir = "$AssembliesDir/$extraExpandDirName"
+            if(Test-Path -Path $extraAssembliesDir) {
+                Copy-Item -Path "$extraAssembliesDir\*" -Destination $AssembliesDir
+                Remove-Item -Path $extraAssembliesDir -Recurse -Force
+            }
             
             # Generate Hash Files 
             Write-Verbose "Generating SHA256 Hash File: $AssembliesDir/$BinaryFileName.sha256"


### PR DESCRIPTION
This pull request is associated with issue: [https://github.com/adamdriscoll/selenium-powershell/issues/234](https://github.com/adamdriscoll/selenium-powershell/issues/234)

The update attempts to download from the [Chrome for Testing JSON endpoints](https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints), using the latest Stable release from their ["Versions" page](https://googlechromelabs.github.io/chrome-for-testing/).

The new endpoint's add an extra folder into the download, so there is an added step to try and remove the extra folder from disk.